### PR TITLE
Fixed HUD not hiding when f1 is on

### DIFF
--- a/src/main/java/com/spyxar/tiptapshow/KeystrokeOverlay.java
+++ b/src/main/java/com/spyxar/tiptapshow/KeystrokeOverlay.java
@@ -45,6 +45,10 @@ public class KeystrokeOverlay implements HudRenderCallback
         {
             return;
         }
+        if (client.options.hudHidden)
+        {
+            return;
+        }
 
         ArrayList<Row> unfinishedRows = new ArrayList<>();
         int x = (int) (config.horizontalSlider / client.getWindow().getScaleFactor());


### PR DESCRIPTION
This makes it so the HUD will not render when `client.options.hudHidden` is true, or in user's terms, when f1 is toggled.